### PR TITLE
⚡ Bolt: Remove redundant DOM text measurements in imports

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-06-25 - Redundant synchronous DOM text measurements during render loops
+
+**Learning:** In Tldraw, `measureText` and `getTextBox` are synchronous operations that interact directly with the DOM. When rendering complex structures like Markdown Tables and Gantt charts, calling them twice per node (once for sizing, once for alignment/drawing) causes significant performance degradation via redundant DOM reads and layout thrashing. Because Markdown tables might contain missing cells (irregular grid), iterating up to the maximum columns rather than the current row length when computing measurements is required to avoid crashing during the render pass.
+
+**Action:** Always inspect loops containing `measureText` or `getTextBox` to verify that their outputs are cached in the data model (e.g. `labelBox.textH`, custom row layout maps). Do not throw away dimensions derived during layout calculation if they will be needed again during rendering! Ensure your caching structure identically matches the final render iteration limits (i.e. use `model.columns.length` rather than `row.length`).

--- a/packages/importer/src/render/importGantt.ts
+++ b/packages/importer/src/render/importGantt.ts
@@ -30,7 +30,7 @@ export function importGanttModel(editor: Editor, model: GanttModel, baseResult: 
 
 	type Row =
 		| { type: 'section'; label: string; y: number; h: number }
-		| { type: 'task'; task: GanttModel['tasks'][number]; y: number; h: number; barX: number; barW: number }
+		| { type: 'task'; task: GanttModel['tasks'][number]; y: number; h: number; barX: number; barW: number; labelTextHeight: number }
 
 	const rows: Row[] = []
 	let currentY = 0
@@ -49,7 +49,10 @@ export function importGanttModel(editor: Editor, model: GanttModel, baseResult: 
 			const labelBox = getTextBox(editor, task.label, { maxWidth: leftColumnWidth - LABEL_PADDING_X * 2, paddingX: LABEL_PADDING_X, paddingY: LABEL_PADDING_Y, minHeight: MIN_ROW_HEIGHT })
 			const rowHeight = Math.max(MIN_ROW_HEIGHT, labelBox.h)
 			const startOffsetDays = daysBetween(timelineStart, task.startDate)
-			rows.push({ type: 'task', task, y: currentY, h: rowHeight, barX: leftColumnWidth + startOffsetDays * dayWidth, barW: Math.max(dayWidth, task.durationDays * dayWidth) })
+
+			// ⚡ Bolt Optimization: Cache textH so we don't have to call measureText() again
+			// in the secondary drawing loop for this task's label.
+			rows.push({ type: 'task', task, y: currentY, h: rowHeight, barX: leftColumnWidth + startOffsetDays * dayWidth, barW: Math.max(dayWidth, task.durationDays * dayWidth), labelTextHeight: labelBox.textH })
 			currentY += rowHeight
 		}
 		currentY += SECTION_GAP
@@ -87,7 +90,7 @@ export function importGanttModel(editor: Editor, model: GanttModel, baseResult: 
 		createdShapeIds.push(labelId, barId)
 		taskShapeIds.set(row.task.id, barId)
 		const rowTop = offset.y + row.y
-		const labelTextHeight = measureText(editor, row.task.label, { maxWidth: leftColumnWidth - LABEL_PADDING_X * 2 }).h
+		const labelTextHeight = row.labelTextHeight
 		const labelY = rowTop + Math.max(0, (row.h - labelTextHeight) / 2)
 		const barY = rowTop + Math.max(0, (row.h - BAR_HEIGHT) / 2)
 		const shouldLabelBar = row.barW >= 170

--- a/packages/importer/src/render/importMarkdownTable.ts
+++ b/packages/importer/src/render/importMarkdownTable.ts
@@ -16,8 +16,21 @@ export function importMarkdownTableModel(editor: Editor, model: MarkdownTableMod
 	const columnWidths = model.columns.map((_, columnIndex) =>
 		clamp(Math.max(...model.rows.map((row) => getTextBox(editor, row[columnIndex] ?? '', { paddingX: CELL_PADDING_X, paddingY: CELL_PADDING_Y, minWidth: MIN_COLUMN_WIDTH }).w)), MIN_COLUMN_WIDTH, MAX_COLUMN_WIDTH)
 	)
+
+	// ⚡ Bolt Optimization: Cache text measurements to avoid redundant DOM reads during render
+	// Markdown tables measure O(rows * cols) text boxes. We compute these once here and store
+	// both the outer height (for row sizing) and the inner text dimensions (for alignment).
+	const cellMeasures: { w: number; h: number }[][] = []
 	const rowHeights = model.rows.map((row, rowIndex) => {
-		const measuredCells = row.map((cell, columnIndex) => getTextBox(editor, cell ?? '', { maxWidth: columnWidths[columnIndex] - CELL_PADDING_X * 2, paddingX: CELL_PADDING_X, paddingY: CELL_PADDING_Y, minHeight: MIN_ROW_HEIGHT }).h)
+		const rowMeasures: { w: number; h: number }[] = []
+		const measuredCells: number[] = []
+		for (let columnIndex = 0; columnIndex < model.columns.length; columnIndex++) {
+			const cell = row[columnIndex] ?? ''
+			const box = getTextBox(editor, cell, { maxWidth: columnWidths[columnIndex] - CELL_PADDING_X * 2, paddingX: CELL_PADDING_X, paddingY: CELL_PADDING_Y, minHeight: MIN_ROW_HEIGHT })
+			rowMeasures.push({ w: box.textW, h: box.textH })
+			measuredCells.push(box.h)
+		}
+		cellMeasures.push(rowMeasures)
 		return Math.max(MIN_ROW_HEIGHT, ...measuredCells, rowIndex === model.headerRowIndex ? 54 : MIN_ROW_HEIGHT)
 	})
 
@@ -58,7 +71,7 @@ export function importMarkdownTableModel(editor: Editor, model: MarkdownTableMod
 			const text = model.rows[rowIndex][columnIndex] ?? ''
 			const cellWidth = columnWidths[columnIndex]
 			const cellHeight = rowHeights[rowIndex]
-			const textMeasure = measureText(editor, text, { maxWidth: cellWidth - CELL_PADDING_X * 2 })
+			const textMeasure = cellMeasures[rowIndex][columnIndex]
 			let textX = x + CELL_PADDING_X
 			if (model.columns[columnIndex]?.align === 'middle') textX = x + (cellWidth - textMeasure.w) / 2
 			else if (model.columns[columnIndex]?.align === 'end') textX = x + cellWidth - CELL_PADDING_X - textMeasure.w


### PR DESCRIPTION
💡 **What**: Added caching for text measurements derived during the initial sizing and layout phase of imports (specifically for Markdown tables and Gantt charts). The measured widths and heights are stored (either in the row array or `cellMeasures` grid) and re-used during the rendering loop.

🎯 **Why**: Tldraw's `measureText` and `getTextBox` are synchronous operations that read directly from the DOM, causing layout thrashing when called repeatedly. By computing text bounds during the layout pass and then blindly recalculating them during drawing, we were doing double the DOM reads. 

📊 **Impact**: Reduces synchronous `measureText` calls by ~50% for complex charts and tables, eliminating `O(rows * cols)` and `O(tasks)` duplicate DOM measurement reads.

🔬 **Measurement**: Verify by importing a large Markdown table or complex Gantt chart; the main thread will block for significantly less time during shape generation.

---
*PR created automatically by Jules for task [16474295712763730562](https://jules.google.com/task/16474295712763730562) started by @standard-librarian*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Gantt chart rendering performance through text measurement caching, significantly reducing redundant DOM calculations during render cycles.
  * Enhanced Markdown table rendering efficiency by implementing cell measurement caching to more effectively handle complex table structures.

* **Documentation**
  * Added internal documentation on text measurement optimization best practices and strategies for improving rendering performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->